### PR TITLE
Refactor isbn_verifier.sh to improve readability

### DIFF
--- a/bash/isbn-verifier/HELP.md
+++ b/bash/isbn-verifier/HELP.md
@@ -1,0 +1,105 @@
+# Help
+
+## Running the tests
+
+Each exercise contains a test file.
+Run the tests using the `bats` program.
+
+```bash
+bats hello_world.bats
+```
+
+`bats` will need to be installed.
+See the [Testing on the Bash track][tests] page for instructions to install `bats` for your system.
+
+[tests]: https://exercism.org/docs/tracks/bash/tests
+
+## Help for assert functions
+
+The tests use functions from the [bats-assert][bats-assert] library.
+Help for the various `assert*` functions can be found there.
+
+[bats-assert]: https://github.com/bats-core/bats-assert
+
+## Skipped tests
+
+Solving an exercise means making all its tests pass.
+By default, only one test (the first one) is executed when you run the tests.
+This is intentional, as it allows you to focus on just making that one test pass.
+Once it passes, you can enable the next test by commenting out or removing the next annotation:
+
+```bash
+[[ $BATS_RUN_SKIPPED == true ]] || skip
+```
+
+## Overriding skips
+
+To run all tests, including the ones with `skip` annotations, you can run:
+
+```bash
+BATS_RUN_SKIPPED=true bats exercise_name.bats
+```
+
+It can be convenient to use a wrapper function to save on typing:
+
+```bash
+bats() {
+    BATS_RUN_SKIPPED=true command bats *.bats
+}
+```
+
+Then run tests with just:
+
+```bash
+bats
+```
+
+## Submitting your solution
+
+You can submit your solution using the `exercism submit isbn_verifier.sh` command.
+This command will upload your solution to the Exercism website and print the solution page's URL.
+
+It's possible to submit an incomplete solution which allows you to:
+
+- See how others have completed the exercise
+- Request help from a mentor
+
+## Need to get help?
+
+If you'd like help solving the exercise, check the following pages:
+
+- The [Bash track's documentation](https://exercism.org/docs/tracks/bash)
+- [Exercism's programming category on the forum](https://forum.exercism.org/c/programming/5)
+- The [Frequently Asked Questions](https://exercism.org/docs/using/faqs)
+
+Should those resources not suffice, you could submit your (incomplete) solution to request mentoring.
+
+Check your code for syntax errors: paste your code into
+[https://shellcheck.net](https://shellcheck.net) (or [install it](https://github.com/koalaman/shellcheck#user-content-installing) on your machine).
+
+Stack Overflow will be your first stop for bash questions.
+
+* start with the [`bash` tag](https://stackoverflow.com/questions/tagged/bash) to search for your specific question: it's probably already been asked
+* under the bash tag on Stackoverflow, the [Learn more...](https://stackoverflow.com/tags/bash/info) link has _tons_ of good information.
+    * the "Books and Resources" section is particularly useful.
+* the [`bash` tag](https://unix.stackexchange.com/questions/tagged/bash) on Unix & Linux is also active
+
+## External utilities
+
+`bash` is a language to write "scripts" -- programs that can call
+external tools, such as
+[`sed`](https://www.gnu.org/software/sed/),
+[`awk`](https://www.gnu.org/software/gawk/),
+[`date`](https://www.gnu.org/software/coreutils/manual/html_node/date-invocation.html)
+and even programs written in other programming languages, 
+like [`Python`](https://www.python.org/).
+This track does not restrict the usage of these utilities, and as long
+as your solution is portable between systems and does not require
+installation of third party applications, feel free to use them to solve
+the exercise.
+
+For an extra challenge, if you would like to have a better understanding of
+the language, try to re-implement the solution in pure bash, without using
+any external tools. There are some types of problems that bash cannot solve,
+such as floating point arithmetic and manipulating dates: for those, you
+must call out to an external tool.

--- a/bash/isbn-verifier/README.md
+++ b/bash/isbn-verifier/README.md
@@ -1,0 +1,64 @@
+# ISBN Verifier
+
+Welcome to ISBN Verifier on Exercism's Bash Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+The [ISBN-10 verification process][isbn-verification] is used to validate book identification numbers.
+These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only).
+In the case the check character is an X, this represents the value '10'.
+These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```text
+(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`.
+We plug it in to the formula, and get:
+
+```text
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+Given a string the program should check if the provided string is a valid ISBN-10.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10').
+For instance `3-598-21507-X` is a valid ISBN-10.
+
+[isbn-verification]: https://en.wikipedia.org/wiki/International_Standard_Book_Number
+
+## Source
+
+### Created by
+
+- @guygastineau
+
+### Contributed to by
+
+- @bkhl
+- @glennj
+- @IsaacG
+- @kotp
+
+### Based on
+
+Converting a string into a number and some basic processing utilizing a relatable real world example. - https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation

--- a/bash/isbn-verifier/bats-extra.bash
+++ b/bash/isbn-verifier/bats-extra.bash
@@ -1,0 +1,637 @@
+# This is the source code for bats-support and bats-assert, concatenated
+# * https://github.com/bats-core/bats-support
+# * https://github.com/bats-core/bats-assert
+#
+# Comments have been removed to save space. See the git repos for full source code.
+
+############################################################
+#
+# bats-support - Supporting library for Bats test helpers
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+fail() {
+  (( $# == 0 )) && batslib_err || batslib_err "$@"
+  return 1
+}
+
+batslib_is_caller() {
+  local -i is_mode_direct=1
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -i|--indirect) is_mode_direct=0; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # Arguments.
+  local -r func="$1"
+
+  # Check call stack.
+  if (( is_mode_direct )); then
+    [[ $func == "${FUNCNAME[2]}" ]] && return 0
+  else
+    local -i depth
+    for (( depth=2; depth<${#FUNCNAME[@]}; ++depth )); do
+      [[ $func == "${FUNCNAME[$depth]}" ]] && return 0
+    done
+  fi
+
+  return 1
+}
+
+batslib_err() {
+  { if (( $# > 0 )); then
+      echo "$@"
+    else
+      cat -
+    fi
+  } >&2
+}
+
+batslib_count_lines() {
+  local -i n_lines=0
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    (( ++n_lines ))
+  done < <(printf '%s' "$1")
+  echo "$n_lines"
+}
+
+batslib_is_single_line() {
+  for string in "$@"; do
+    (( $(batslib_count_lines "$string") > 1 )) && return 1
+  done
+  return 0
+}
+
+batslib_get_max_single_line_key_width() {
+  local -i max_len=-1
+  while (( $# != 0 )); do
+    local -i key_len="${#1}"
+    batslib_is_single_line "$2" && (( key_len > max_len )) && max_len="$key_len"
+    shift 2
+  done
+  echo "$max_len"
+}
+
+batslib_print_kv_single() {
+  local -ir col_width="$1"; shift
+  while (( $# != 0 )); do
+    printf '%-*s : %s\n' "$col_width" "$1" "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_multi() {
+  while (( $# != 0 )); do
+    printf '%s (%d lines):\n' "$1" "$( batslib_count_lines "$2" )"
+    printf '%s\n' "$2"
+    shift 2
+  done
+}
+
+batslib_print_kv_single_or_multi() {
+  local -ir width="$1"; shift
+  local -a pairs=( "$@" )
+
+  local -a values=()
+  local -i i
+  for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+    values+=( "${pairs[$i]}" )
+  done
+
+  if batslib_is_single_line "${values[@]}"; then
+    batslib_print_kv_single "$width" "${pairs[@]}"
+  else
+    local -i i
+    for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+    done
+    batslib_print_kv_multi "${pairs[@]}"
+  fi
+}
+
+batslib_prefix() {
+  local -r prefix="${1:-  }"
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    printf '%s%s\n' "$prefix" "$line"
+  done
+}
+
+batslib_mark() {
+  local -r symbol="$1"; shift
+  # Sort line numbers.
+  set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
+
+  local line
+  local -i idx=0
+  while IFS='' read -r line || [[ -n $line ]]; do
+    if (( ${1:--1} == idx )); then
+      printf '%s\n' "${symbol}${line:${#symbol}}"
+      shift
+    else
+      printf '%s\n' "$line"
+    fi
+    (( ++idx ))
+  done
+}
+
+batslib_decorate() {
+  echo
+  echo "-- $1 --"
+  cat -
+  echo '--'
+  echo
+}
+
+############################################################
+
+assert() {
+  if ! "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion failed' \
+    | fail
+  fi
+}
+
+assert_equal() {
+  if [[ $1 != "$2" ]]; then
+    batslib_print_kv_single_or_multi 8 \
+    'expected' "$2" \
+    'actual'   "$1" \
+    | batslib_decorate 'values do not equal' \
+    | fail
+  fi
+}
+
+assert_failure() {
+  : "${output?}"
+  : "${status?}"
+
+  (( $# > 0 )) && local -r expected="$1"
+  if (( status == 0 )); then
+    batslib_print_kv_single_or_multi 6 'output' "$output" \
+    | batslib_decorate 'command succeeded, but it was expected to fail' \
+    | fail
+  elif (( $# > 0 )) && (( status != expected )); then
+    { local -ir width=8
+      batslib_print_kv_single "$width" \
+      'expected' "$expected" \
+      'actual'   "$status"
+      batslib_print_kv_single_or_multi "$width" \
+      'output' "$output"
+    } \
+    | batslib_decorate 'command failed as expected, but status differs' \
+    | fail
+  fi
+}
+
+assert_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: assert_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r expected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $expected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$expected'" \
+    | batslib_decorate 'ERROR: assert_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if ! [[ ${lines[$idx]} =~ $expected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$expected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression does not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} != *"$expected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$expected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line does not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} != "$expected" ]]; then
+        batslib_print_kv_single 8 \
+        'index'    "$idx" \
+        'expected' "$expected" \
+        'actual'   "${lines[$idx]}" \
+        | batslib_decorate 'line differs' \
+        | fail
+      fi
+    fi
+  else
+    # Contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} =~ $expected ]] && return 0
+      done
+      { local -ar single=( 'regexp' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line matches regular expression' \
+      | fail
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == *"$expected"* ]] && return 0
+      done
+      { local -ar single=( 'substring' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'no output line contains substring' \
+      | fail
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == "$expected" ]] && return 0
+      done
+      { local -ar single=( 'line' "$expected" )
+        local -ar may_be_multi=( 'output' "$output" )
+        local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } \
+      | batslib_decorate 'output does not contain line' \
+      | fail
+    fi
+  fi
+}
+
+assert_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_nonempty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_nonempty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: assert_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local expected
+  if (( use_stdin )); then
+    expected="$(cat -)"
+  else
+    expected="${1-}"
+  fi
+
+  # Matching.
+  if (( is_mode_nonempty )); then
+    if [ -z "$output" ]; then
+      echo 'expected non-empty output, but output was empty' \
+      | batslib_decorate 'no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      echo "Invalid extended regular expression: \`$expected'" \
+      | batslib_decorate 'ERROR: assert_output' \
+      | fail
+    elif ! [[ $output =~ $expected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$expected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression does not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output != *"$expected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$expected" \
+      'output'    "$output" \
+      | batslib_decorate 'output does not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output != "$expected" ]]; then
+      batslib_print_kv_single_or_multi 8 \
+      'expected' "$expected" \
+      'actual'   "$output" \
+      | batslib_decorate 'output differs' \
+      | fail
+    fi
+  fi
+}
+
+assert_success() {
+  : "${output?}"
+  : "${status?}"
+
+  if (( status != 0 )); then
+    { local -ir width=6
+      batslib_print_kv_single "$width" 'status' "$status"
+      batslib_print_kv_single_or_multi "$width" 'output' "$output"
+    } \
+    | batslib_decorate 'command failed' \
+    | fail
+  fi
+}
+
+refute() {
+  if "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+    | batslib_decorate 'assertion succeeded, but it was expected to fail' \
+    | fail
+  fi
+}
+
+refute_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  : "${lines?}"
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+    -n|--index)
+      if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+        echo "\`--index' requires an integer argument: \`$2'" \
+        | batslib_decorate 'ERROR: refute_line' \
+        | fail
+        return $?
+      fi
+      is_match_line=1
+      local -ri idx="$2"
+      shift 2
+      ;;
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r unexpected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_line' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if [[ ${lines[$idx]} =~ $unexpected ]]; then
+        batslib_print_kv_single 6 \
+        'index' "$idx" \
+        'regexp' "$unexpected" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'regular expression should not match line' \
+        | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+        batslib_print_kv_single 9 \
+        'index'     "$idx" \
+        'substring' "$unexpected" \
+        'line'      "${lines[$idx]}" \
+        | batslib_decorate 'line should not contain substring' \
+        | fail
+      fi
+    else
+      if [[ ${lines[$idx]} == "$unexpected" ]]; then
+        batslib_print_kv_single 5 \
+        'index' "$idx" \
+        'line'  "${lines[$idx]}" \
+        | batslib_decorate 'line should differ' \
+        | fail
+      fi
+    fi
+  else
+    # Line contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} =~ $unexpected ]]; then
+          { local -ar single=( 'regexp' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should match the regular expression' \
+          | fail
+          return $?
+        fi
+      done
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+          { local -ar single=( 'substring' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'no line should contain substring' \
+          | fail
+          return $?
+        fi
+      done
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$unexpected" ]]; then
+          { local -ar single=( 'line' "$unexpected" 'index' "$idx" )
+            local -a may_be_multi=( 'output' "$output" )
+            local -ir width="$( batslib_get_max_single_line_key_width "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" | batslib_prefix | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } \
+          | batslib_decorate 'line should not be in output' \
+          | fail
+          return $?
+        fi
+      done
+    fi
+  fi
+}
+
+refute_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+  local -i is_mode_empty=0
+  local -i use_stdin=0
+  : "${output?}"
+
+  # Handle options.
+  if (( $# == 0 )); then
+    is_mode_empty=1
+  fi
+
+  while (( $# > 0 )); do
+    case "$1" in
+    -p|--partial) is_mode_partial=1; shift ;;
+    -e|--regexp) is_mode_regexp=1; shift ;;
+    -|--stdin) use_stdin=1; shift ;;
+    --) shift; break ;;
+    *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Arguments.
+  local unexpected
+  if (( use_stdin )); then
+    unexpected="$(cat -)"
+  else
+    unexpected="${1-}"
+  fi
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+    | batslib_decorate 'ERROR: refute_output' \
+    | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_mode_empty )); then
+    if [ -n "$output" ]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output non-empty, but expected no output' \
+      | fail
+    fi
+  elif (( is_mode_regexp )); then
+    if [[ $output =~ $unexpected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'regexp'  "$unexpected" \
+      'output' "$output" \
+      | batslib_decorate 'regular expression should not match output' \
+      | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output == *"$unexpected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+      'substring' "$unexpected" \
+      'output'    "$output" \
+      | batslib_decorate 'output should not contain substring' \
+      | fail
+    fi
+  else
+    if [[ $output == "$unexpected" ]]; then
+      batslib_print_kv_single_or_multi 6 \
+      'output' "$output" \
+      | batslib_decorate 'output equals, but it was expected to differ' \
+      | fail
+    fi
+  fi
+}

--- a/bash/isbn-verifier/isbn_verifier.bats
+++ b/bash/isbn-verifier/isbn_verifier.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 2.7.0.0
+
+@test 'valid isbn number' {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21508-8'
+  assert_success
+  assert_output "true"
+}
+
+@test 'invalid isbn check digit' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21508-9'
+  assert_success
+  assert_output "false"
+}
+
+@test 'valid isbn number with a check digit of 10' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21507-X'
+  assert_success
+  assert_output "true"
+}
+
+@test 'check digit is a character other than X' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21507-A'
+  assert_success
+  assert_output "false"
+}
+
+@test 'invalid check digit in isbn is not treated as zero' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '4-598-21507-B'
+  assert_success
+  assert_output "false"
+}
+
+@test 'invalid character in isbn' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-P1581-X'
+  assert_success
+  assert_output "false"
+}
+
+@test 'X is only valid as a check digit' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-2X507-9'
+  assert_success
+  assert_output "false"
+}
+
+@test 'valid isbn without separating dashes' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3598215088'
+  assert_success
+  assert_output "true"
+}
+
+@test 'isbn without separating dashes and X as check digit' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '359821507X'
+  assert_success
+  assert_output "true"
+}
+
+@test 'isbn without check digit and dashes' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '359821507'
+  assert_success
+  assert_output "false"
+}
+
+@test 'too long isbn and no dashes' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3598215078X'
+  assert_success
+  assert_output "false"
+}
+
+@test 'too short isbn' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '00'
+  assert_success
+  assert_output "false"
+}
+
+@test 'isbn without check digit' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21507'
+  assert_success
+  assert_output "false"
+}
+
+@test 'check digit of X should not be used for 0' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3-598-21515-X'
+  assert_success
+  assert_output "false"
+}
+
+@test 'empty isbn' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh ''
+  assert_success
+  assert_output "false"
+}
+
+@test 'input is 9 characters' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '134456729'
+  assert_success
+  assert_output "false"
+}
+
+@test 'invalid characters are not ignored' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3132P34035'
+  assert_success
+  assert_output "false"
+}
+
+@test 'invalid characters are not ignored before checking length' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '3598P215088'
+  assert_success
+  assert_output "false"
+}
+
+@test 'input is too long but contains a valid isbn' {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash isbn_verifier.sh '98245726788'
+  assert_success
+  assert_output "false"
+}

--- a/bash/isbn-verifier/isbn_verifier.sh
+++ b/bash/isbn-verifier/isbn_verifier.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# The following comments should help you get started:
+# - Bash is flexible. You may use functions or write a "raw" script.
+#
+# - Complex code can be made easier to read by breaking it up
+#   into functions, however this is sometimes overkill in bash.
+#
+# - You can find links about good style and other resources
+#   for Bash in './README.md'. It came with this exercise.
+#
+#   Example:
+#   # other functions here
+#   # ...
+#   # ...
+#
+#   main () {
+#     # your main function code here
+#   }
+#
+#   # call main with all of the positional arguments
+#   main "$@"
+#
+# *** PLEASE REMOVE THESE COMMENTS BEFORE SUBMITTING YOUR SOLUTION ***

--- a/bash/isbn-verifier/isbn_verifier.sh
+++ b/bash/isbn-verifier/isbn_verifier.sh
@@ -1,22 +1,18 @@
 #!/usr/bin/env bash
 
-false() {
-  echo "false"
-  exit 0
-}
-
-main() {
+function check_isbn {
   local isbn=${1//-/}
-  [[ $isbn =~ ^[[:digit:]]{9}[[:digit:]X]$ ]] || false
+  [[ $isbn =~ ^[[:digit:]]{9}[[:digit:]X]$ ]] || return 1
 
-  local -i sum=$((${isbn: -1} == "X" ? 10 : ${isbn: -1}))
-  local -i i=10
+  local -i i=10 sum=0
   while ((i > 1)); do
     ((sum += ${isbn: -i:1} * i--))
   done
 
-  ((sum % 11)) && false
-  echo "true"
+  local check=${isbn: -1}
+  ((sum += ${check/X/10}))
+  ((sum % 11)) && return 1
+  return 0
 }
 
-main "$@"
+check_isbn "$@" && echo true || echo false

--- a/bash/isbn-verifier/isbn_verifier.sh
+++ b/bash/isbn-verifier/isbn_verifier.sh
@@ -1,62 +1,22 @@
 #!/usr/bin/env bash
 
-#Instructions
-#
-#The ISBN-10 verification process is used to validate book identification numbers. These normally contain dashes and look like: 3-598-21508-8
-#ISBN
-#
-#The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
-#
-#(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
-#
-#If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
-#Example
-#
-#Let's take the ISBN-10 3-598-21508-8. We plug it in to the formula, and get:
-#
-#(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
-#
-#Since the result is 0, this proves that our ISBN is valid.
-#Task
-#
-#Given a string the program should check if the provided string is a valid ISBN-10. Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
-#
-#The program should be able to verify ISBN-10 both with and without separating dashes.
-#Caveats
-#
-#Converting from strings to numbers can be tricky in certain languages. Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance 3-598-21507-X is a valid ISBN-10.
-
 false() {
-    echo "false"
-    exit 0
+  echo "false"
+  exit 0
 }
 
-main () {
-    local isbn=${1//-/}
-    local sum=0
-    local i=10
-    local digit
+main() {
+  local isbn=${1//-/}
+  [[ $isbn =~ ^[[:digit:]]{9}[[:digit:]X]$ ]] || false
 
-    [[ $isbn =~ ^[0-9]{9}[0-9X]$ ]] || false
+  local -i sum=$((${isbn: -1} == "X" ? 10 : ${isbn: -1}))
+  local -i i=10
+  while ((i > 1)); do
+    ((sum += ${isbn: -i:1} * i--))
+  done
 
-    if [[ ${#isbn} -ne 10 ]]; then
-        echo "false"
-        exit 0
-    fi
-
-    for digit in $(echo $isbn | grep -o .); do
-        if [[ $digit == "X" ]]; then
-            digit=10
-        fi
-        sum=$((sum + digit * i))
-        ((i--))
-    done
-
-    if [[ $((sum % 11)) -eq 0 ]]; then
-        echo "true"
-    else
-        echo "false"
-    fi
+  ((sum % 11)) && false
+  echo "true"
 }
 
 main "$@"

--- a/bash/isbn-verifier/isbn_verifier.sh
+++ b/bash/isbn-verifier/isbn_verifier.sh
@@ -1,24 +1,62 @@
 #!/usr/bin/env bash
 
-# The following comments should help you get started:
-# - Bash is flexible. You may use functions or write a "raw" script.
+#Instructions
 #
-# - Complex code can be made easier to read by breaking it up
-#   into functions, however this is sometimes overkill in bash.
+#The ISBN-10 verification process is used to validate book identification numbers. These normally contain dashes and look like: 3-598-21508-8
+#ISBN
 #
-# - You can find links about good style and other resources
-#   for Bash in './README.md'. It came with this exercise.
+#The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
 #
-#   Example:
-#   # other functions here
-#   # ...
-#   # ...
+#(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
 #
-#   main () {
-#     # your main function code here
-#   }
+#If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+#Example
 #
-#   # call main with all of the positional arguments
-#   main "$@"
+#Let's take the ISBN-10 3-598-21508-8. We plug it in to the formula, and get:
 #
-# *** PLEASE REMOVE THESE COMMENTS BEFORE SUBMITTING YOUR SOLUTION ***
+#(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+#
+#Since the result is 0, this proves that our ISBN is valid.
+#Task
+#
+#Given a string the program should check if the provided string is a valid ISBN-10. Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+#
+#The program should be able to verify ISBN-10 both with and without separating dashes.
+#Caveats
+#
+#Converting from strings to numbers can be tricky in certain languages. Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance 3-598-21507-X is a valid ISBN-10.
+
+false() {
+    echo "false"
+    exit 0
+}
+
+main () {
+    local isbn=${1//-/}
+    local sum=0
+    local i=10
+    local digit
+
+    [[ $isbn =~ ^[0-9]{9}[0-9X]$ ]] || false
+
+    if [[ ${#isbn} -ne 10 ]]; then
+        echo "false"
+        exit 0
+    fi
+
+    for digit in $(echo $isbn | grep -o .); do
+        if [[ $digit == "X" ]]; then
+            digit=10
+        fi
+        sum=$((sum + digit * i))
+        ((i--))
+    done
+
+    if [[ $((sum % 11)) -eq 0 ]]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+main "$@"

--- a/bash/rna-transcription/rna_transcription.sh
+++ b/bash/rna-transcription/rna_transcription.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
-# bashsupport disable=SpellCheckingInspection
-tr "GCTA" "CGAU"
+
+die() {
+  echo >&2 "$@"
+  exit 1
+}
+
+[[ $1 =~ ^[GCTA]*$ ]] &&
+  tr "GCTA" "CGAU" <<<"$1" || die "Invalid nucleotide detected."

--- a/bash/rna-transcription/rna_transcription.sh
+++ b/bash/rna-transcription/rna_transcription.sh
@@ -5,5 +5,6 @@ die() {
   exit 1
 }
 
-[[ $1 =~ ^[GCTA]*$ ]] &&
-  tr "GCTA" "CGAU" <<<"$1" || die "Invalid nucleotide detected."
+[[ $1 =~ ^[GCTA]*$ ]] || die "Invalid nucleotide detected."
+
+tr "GCTA" "CGAU" <<<"$1"


### PR DESCRIPTION
Refactor isbn_verifier.sh to improve readability

Removed the 'false' function and replaced with return values in the 'check_isbn' function. This makes the code more concise and easier to understand. Also removed unnecessary variables and made use of bash parameter expansion for arithmetic computations. Overall, these changes aim to improve the clarity of the code while preserving its functionality