### PR TITLE
Add Tournament.ps1 script, test cases, README.md and HELP.md

### DIFF
--- a/powershell/tournament/HELP.md
+++ b/powershell/tournament/HELP.md
@@ -1,0 +1,34 @@
+# Help
+
+## Running the tests
+
+To run the tests run the command `Invoke-Pester` from within the exercise directory.
+
+## Submitting your solution
+
+You can submit your solution using the `exercism submit Tournament.ps1` command.
+This command will upload your solution to the Exercism website and print the solution page's URL.
+
+It's possible to submit an incomplete solution which allows you to:
+
+- See how others have completed the exercise
+- Request help from a mentor
+
+## Need to get help?
+
+If you'd like help solving the exercise, check the following pages:
+
+- The [PowerShell track's documentation](https://exercism.org/docs/tracks/powershell)
+- The [PowerShell track's programming category on the forum](https://forum.exercism.org/c/programming/powershell)
+- [Exercism's programming category on the forum](https://forum.exercism.org/c/programming/5)
+- The [Frequently Asked Questions](https://exercism.org/docs/using/faqs)
+
+Should those resources not suffice, you could submit your (incomplete) solution to request mentoring.
+
+To get help if you are having trouble, you can use one of the following resources:
+
+- [Powershell Documentation][powershell docs]
+
+[Add more resources]: TODO
+
+[powershell docs]: https://docs.microsoft.com/en-us/powershell/

--- a/powershell/tournament/README.md
+++ b/powershell/tournament/README.md
@@ -1,0 +1,77 @@
+# Tournament
+
+Welcome to Tournament on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Tally the results of a small football competition.
+
+Based on an input file containing which team played against which and what the outcome was, create a file with a table like this:
+
+```text
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1
+```
+
+What do those abbreviations mean?
+
+- MP: Matches Played
+- W: Matches Won
+- D: Matches Drawn (Tied)
+- L: Matches Lost
+- P: Points
+
+A win earns a team 3 points.
+A draw earns 1.
+A loss earns 0.
+
+The outcome is ordered by points, descending.
+In case of a tie, teams are ordered alphabetically.
+
+## Input
+
+Your tallying program will receive input that looks like:
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win
+```
+
+The result of the match refers to the first team listed.
+So this line:
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+```
+
+means that the Allegoric Alaskans beat the Blithering Badgers.
+
+This line:
+
+```text
+Courageous Californians;Blithering Badgers;loss
+```
+
+means that the Blithering Badgers beat the Courageous Californians.
+
+And this line:
+
+```text
+Devastating Donkeys;Courageous Californians;draw
+```
+
+means that the Devastating Donkeys and Courageous Californians tied.
+
+## Source
+
+### Created by
+
+- @glaxxie

--- a/powershell/tournament/Tournament.ps1
+++ b/powershell/tournament/Tournament.ps1
@@ -1,0 +1,77 @@
+Function Invoke-Tournament {
+    <#
+    .SYNOPSIS
+    Tally the results of a small football competition.
+
+    .DESCRIPTION
+    Given an array of string containing which team played against which and what the outcome was, create a tally table.
+
+    .PARAMETER Results
+    An array of the string, each line represent a match being played and its outcome.
+
+    .EXAMPLE
+    Invoke-Tournament -Results @("Annalyn;Elyses;win")
+    
+    return:
+    @"
+    Team                           | MP |  W |  D |  L |  P
+    Annalyn                        |  1 |  1 |  0 |  0 |  3
+    Elyses                         |  1 |  0 |  0 |  1 |  0
+    "@
+    #>
+    [CmdletBinding()]
+    Param(
+        [string[]]$Results
+    )
+
+    class Team {
+        [string]$Name
+        [int]$MP
+        [int]$W
+        [int]$D
+        [int]$L
+        [int]$P
+    }
+    $Table = @{}
+
+    $Results | 
+    ForEach-Object {
+        $team1, $team2, $result = $_ -split ';'
+        if (-not $Table.ContainsKey($team1)) {
+            $Table[$team1] = [Team]::new()
+            $Table[$team1].Name = $team1
+        }
+        if (-not $Table.ContainsKey($team2)) {
+            $Table[$team2] = [Team]::new()
+            $Table[$team2].Name = $team2
+        }
+        switch ($result) {
+            win { 
+                $Table[$team1].W += 1
+                $Table[$team2].L += 1 
+                $Table[$team1].P += 3
+            }
+            loss { 
+                $Table[$team1].L += 1
+                $Table[$team2].W += 1  
+                $Table[$team2].P += 3
+            }
+            draw {  
+                $Table[$team1].D += 1
+                $Table[$team2].D += 1
+                $Table[$team1].P += 1
+                $Table[$team2].P += 1
+            }
+        }
+        $Table[$team1].MP += 1
+        $Table[$team2].MP += 1
+    }
+
+    $report = @("Team                           | MP |  W |  D |  L |  P")
+    $report += $Table.Values | 
+    Sort-Object -Property @{Expression = "P"; Descending = $true}, @{Expression = "Name"} | 
+    ForEach-Object {
+        "{0,-30} | {1,2} | {2,2} | {3,2} | {4,2} | {5,2}" -f $_.Name, $_.MP, $_.W, $_.D, $_.L, $_.P
+    }
+    $report -join "`n"
+}

--- a/powershell/tournament/Tournament.tests.ps1
+++ b/powershell/tournament/Tournament.tests.ps1
@@ -1,0 +1,162 @@
+BeforeAll {
+    . ".\Tournament.ps1"
+}
+Describe "Tournament test cases" {
+    It "just the header if no input" {
+        $result = @()
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = "Team                           | MP |  W |  D |  L |  P"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "a win is three points, a loss is zero points" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3",
+                    "Blithering Badgers             |  1 |  0 |  0 |  1 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "a win can also be expressed as a loss" {
+        $result = @("Blithering Badgers;Allegoric Alaskans;loss")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3",
+                    "Blithering Badgers             |  1 |  0 |  0 |  1 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "a different team can win" {
+        $result = @("Blithering Badgers;Allegoric Alaskans;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Blithering Badgers             |  1 |  1 |  0 |  0 |  3",
+                    "Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "a draw is one point each" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;draw")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1",
+                    "Blithering Badgers             |  1 |  0 |  1 |  0 |  1") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "There can be more than one match" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;win",
+                    "Allegoric Alaskans;Blithering Badgers;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6",
+                    "Blithering Badgers             |  2 |  0 |  0 |  2 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "There can be more than one winner" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;loss",
+                    "Allegoric Alaskans;Blithering Badgers;win")
+                    
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3",
+                    "Blithering Badgers             |  2 |  1 |  0 |  1 |  3") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "There can be more than two teams" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;win",
+                    "Blithering Badgers;Courageous Californians;win",
+                    "Courageous Californians;Allegoric Alaskans;loss")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6",
+                    "Blithering Badgers             |  2 |  1 |  0 |  1 |  3",
+                    "Courageous Californians        |  2 |  0 |  0 |  2 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "typical input" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;win",
+                    "Devastating Donkeys;Courageous Californians;draw",
+                    "Devastating Donkeys;Allegoric Alaskans;win",
+                    "Courageous Californians;Blithering Badgers;loss",
+                    "Blithering Badgers;Devastating Donkeys;loss",
+                    "Allegoric Alaskans;Courageous Californians;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Devastating Donkeys            |  3 |  2 |  1 |  0 |  7",
+                    "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6",
+                    "Blithering Badgers             |  3 |  1 |  0 |  2 |  3",
+                    "Courageous Californians        |  3 |  0 |  1 |  2 |  1") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "incomplete competition (not all pairs have played)" {
+        $result = @("Allegoric Alaskans;Blithering Badgers;loss",
+                    "Devastating Donkeys;Allegoric Alaskans;loss",
+                    "Courageous Californians;Blithering Badgers;draw",
+                    "Allegoric Alaskans;Courageous Californians;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6",
+                    "Blithering Badgers             |  2 |  1 |  1 |  0 |  4",
+                    "Courageous Californians        |  2 |  0 |  1 |  1 |  1",
+                    "Devastating Donkeys            |  1 |  0 |  0 |  1 |  0") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "ties broken alphabetically" {
+        $result = @("Courageous Californians;Devastating Donkeys;win",
+                    "Allegoric Alaskans;Blithering Badgers;win",
+                    "Devastating Donkeys;Allegoric Alaskans;loss",
+                    "Courageous Californians;Blithering Badgers;win",
+                    "Blithering Badgers;Devastating Donkeys;draw",
+                    "Allegoric Alaskans;Courageous Californians;draw")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7",
+                    "Courageous Californians        |  3 |  2 |  1 |  0 |  7",
+                    "Blithering Badgers             |  3 |  0 |  1 |  2 |  1",
+                    "Devastating Donkeys            |  3 |  0 |  1 |  2 |  1") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "ensure points sorted numerically" {
+        $result = @("Devastating Donkeys;Blithering Badgers;win",
+                    "Devastating Donkeys;Blithering Badgers;win",
+                    "Devastating Donkeys;Blithering Badgers;win",
+                    "Devastating Donkeys;Blithering Badgers;win",
+                    "Blithering Badgers;Devastating Donkeys;win")
+
+        $got    = Invoke-Tournament -Results $result
+        $want   = ( "Team                           | MP |  W |  D |  L |  P",
+                    "Devastating Donkeys            |  5 |  4 |  0 |  1 | 12",
+                    "Blithering Badgers             |  5 |  1 |  0 |  4 |  3") -join "`n"
+
+        $got | Should -BeExactly $want
+    }
+}


### PR DESCRIPTION
This commit introduces a new script - Tournament.ps1, which creates a tally table according to the results of a football competition. It processes input strings that represent matches and their outcomes and outputs a sorted table with stats for each participating team. This update is necessary because it calculates and represents the result of the tournament in a clear and insightful way.

Also, README.md and HELP.md files were added for informative purposes. Besides that, the corresponding .ps1 test case file was added to ensure the functionality of the script.